### PR TITLE
buildチェック用のjobを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,14 @@ jobs:
         with:
           node-version: 18.10.0
 
+      - name: Get node_modules cache
+        uses: actions/cache@v3.0.2
+        id: node_modules
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+
       - run: yarn install
       - run: yarn lint
       - run: yarn build


### PR DESCRIPTION
## 概要
`main`, `development`以外のブランチにpushした場合にbuildとlintを走らせるjobを作成。  

## やったこと
- buildチェック用のjobを追加[35ce57f](https://github.com/ToruShimizu/protein-reviews/pull/11/commits/35ce57f2596ccf1a89749a19e14c78250040d3ff)
- yarn installをキャッシュして高速化 [8b706c3](https://github.com/ToruShimizu/protein-reviews/pull/11/commits/8b706c3bfe98038130316029de055b6e302708e7)

約30秒ほど短縮

<img width="1080" alt="スクリーンショット 2023-07-07 14 52 10" src="https://github.com/ToruShimizu/protein-reviews/assets/65491855/3bdd1ccb-6993-43cf-a510-3ee744a6af2b">