### PR TITLE
yarn.lockが正しくcommitされているかどうかを確認するjobを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-      uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3.1.1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 18.10.0
+          node-version: 18
 
       - name: Get node_modules cache
-      uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         id: node_modules
         with:
           path: |


### PR DESCRIPTION
## 概要
- packageに変更があった際に、yarn.lockのコミット忘れを防止するためにCIで検知できるようにした

## やったこと
- yarn.lockのコミット忘れを検知するjobを追加 [845f2cd](https://github.com/ToruShimizu/protein-reviews/pull/17/commits/845f2cd81a0d9ecb427c8e2c2ccdbdb5b38d45d8)
    - https://github.com/yarnpkg/yarn/issues/4098#issuecomment-610990058 
- 軽微なリファクタ
    -  stepのnameを追加 [8d6d19e](https://github.com/ToruShimizu/protein-reviews/pull/17/commits/8d6d19e538d88ad230a61fcb62c76cb12233b42c)
    - アクションのverを変更 [b475e35](https://github.com/ToruShimizu/protein-reviews/pull/17/commits/b475e3550b155fc8704963d77135aa5303d59ca3)
## 確認項目

yarn.lockのコミット忘れ検知 
https://github.com/ToruShimizu/protein-reviews/actions/runs/5486647485

![スクリーンショット 2023-07-07 22 04 39](https://github.com/ToruShimizu/protein-reviews/assets/65491855/5e2ffdb4-26a7-405f-a873-d2b8a343d0db)


成功
https://github.com/ToruShimizu/protein-reviews/actions/runs/5486667054