### PR TITLE
環境変数をsecretsから読み取るよう修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,13 @@ jobs:
         run: yarn install
 
       - name: Check yarn.lock
-        run: '! git diff --name-only | grep yarn.lock'
+        run: "! git diff --name-only | grep yarn.lock"
 
       - name: Run lint
         run: yarn lint
 
       - name: Build
         run: yarn build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## やったこと
- github actionsで環境変数が読み込めずにエラーになっていたため、環境変数をsecretsから読み取るよう修正 fd9a95c728398bbf4c21e037fc1bceeefe7a2c12
## 関連URL

## 確認項目

## 備考
