### PR TITLE
reviewはproteinに紐づけるように変更したため、レビュー投稿時に渡すパラメータを変更

### DIFF
--- a/api/graphql/generated/graphql.ts
+++ b/api/graphql/generated/graphql.ts
@@ -737,7 +737,6 @@ export type Flavors = Node & {
   protein_id: Scalars['BigInt']['output'];
   proteins: Proteins;
   proteinsCollection?: Maybe<ProteinsConnection>;
-  reviewsCollection?: Maybe<ReviewsConnection>;
   seller_id?: Maybe<Scalars['BigInt']['output']>;
   sellers?: Maybe<Sellers>;
   sellersCollection?: Maybe<SellersConnection>;
@@ -762,16 +761,6 @@ export type FlavorsProteinsCollectionArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<ProteinsOrderBy>>;
-};
-
-
-export type FlavorsReviewsCollectionArgs = {
-  after?: InputMaybe<Scalars['Cursor']['input']>;
-  before?: InputMaybe<Scalars['Cursor']['input']>;
-  filter?: InputMaybe<ReviewsFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<Array<ReviewsOrderBy>>;
 };
 
 
@@ -1133,6 +1122,9 @@ export type Proteins = Node & {
   name: Scalars['String']['output'];
   /** Globally Unique Record Identifier */
   nodeId: Scalars['ID']['output'];
+  review_id?: Maybe<Scalars['BigInt']['output']>;
+  reviews?: Maybe<Reviews>;
+  reviewsCollection?: Maybe<ReviewsConnection>;
   src: Scalars['String']['output'];
 };
 
@@ -1176,6 +1168,16 @@ export type ProteinsMakersCollectionArgs = {
   orderBy?: InputMaybe<Array<MakersOrderBy>>;
 };
 
+
+export type ProteinsReviewsCollectionArgs = {
+  after?: InputMaybe<Scalars['Cursor']['input']>;
+  before?: InputMaybe<Scalars['Cursor']['input']>;
+  filter?: InputMaybe<ReviewsFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<ReviewsOrderBy>>;
+};
+
 export type ProteinsConnection = {
   __typename?: 'proteinsConnection';
   edges: Array<ProteinsEdge>;
@@ -1203,6 +1205,7 @@ export type ProteinsFilter = {
   maker_id?: InputMaybe<BigIntFilter>;
   name?: InputMaybe<StringFilter>;
   nodeId?: InputMaybe<IdFilter>;
+  review_id?: InputMaybe<BigIntFilter>;
   src?: InputMaybe<StringFilter>;
 };
 
@@ -1211,6 +1214,7 @@ export type ProteinsInsertInput = {
   flavor_id?: InputMaybe<Scalars['BigInt']['input']>;
   maker_id?: InputMaybe<Scalars['BigInt']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  review_id?: InputMaybe<Scalars['BigInt']['input']>;
   src?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1228,6 +1232,7 @@ export type ProteinsOrderBy = {
   id?: InputMaybe<OrderByDirection>;
   maker_id?: InputMaybe<OrderByDirection>;
   name?: InputMaybe<OrderByDirection>;
+  review_id?: InputMaybe<OrderByDirection>;
   src?: InputMaybe<OrderByDirection>;
 };
 
@@ -1236,6 +1241,7 @@ export type ProteinsUpdateInput = {
   flavor_id?: InputMaybe<Scalars['BigInt']['input']>;
   maker_id?: InputMaybe<Scalars['BigInt']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  review_id?: InputMaybe<Scalars['BigInt']['input']>;
   src?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1251,14 +1257,26 @@ export type Reviews = Node & {
   __typename?: 'reviews';
   created_at?: Maybe<Scalars['Datetime']['output']>;
   description: Scalars['String']['output'];
-  flavor_id: Scalars['BigInt']['output'];
-  flavors: Flavors;
+  favorite?: Maybe<Scalars['String']['output']>;
   id: Scalars['BigInt']['output'];
   name: Scalars['String']['output'];
   /** Globally Unique Record Identifier */
   nodeId: Scalars['ID']['output'];
-  rate: Scalars['BigInt']['output'];
+  protein_id: Scalars['BigInt']['output'];
+  proteins: Proteins;
+  proteinsCollection?: Maybe<ProteinsConnection>;
+  rate: Scalars['BigFloat']['output'];
   title: Scalars['String']['output'];
+};
+
+
+export type ReviewsProteinsCollectionArgs = {
+  after?: InputMaybe<Scalars['Cursor']['input']>;
+  before?: InputMaybe<Scalars['Cursor']['input']>;
+  filter?: InputMaybe<ProteinsFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<ProteinsOrderBy>>;
 };
 
 export type ReviewsConnection = {
@@ -1284,20 +1302,22 @@ export type ReviewsEdge = {
 export type ReviewsFilter = {
   created_at?: InputMaybe<DatetimeFilter>;
   description?: InputMaybe<StringFilter>;
-  flavor_id?: InputMaybe<BigIntFilter>;
+  favorite?: InputMaybe<StringFilter>;
   id?: InputMaybe<BigIntFilter>;
   name?: InputMaybe<StringFilter>;
   nodeId?: InputMaybe<IdFilter>;
-  rate?: InputMaybe<BigIntFilter>;
+  protein_id?: InputMaybe<BigIntFilter>;
+  rate?: InputMaybe<BigFloatFilter>;
   title?: InputMaybe<StringFilter>;
 };
 
 export type ReviewsInsertInput = {
   created_at?: InputMaybe<Scalars['Datetime']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
-  flavor_id?: InputMaybe<Scalars['BigInt']['input']>;
+  favorite?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
-  rate?: InputMaybe<Scalars['BigInt']['input']>;
+  protein_id?: InputMaybe<Scalars['BigInt']['input']>;
+  rate?: InputMaybe<Scalars['BigFloat']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1312,9 +1332,10 @@ export type ReviewsInsertResponse = {
 export type ReviewsOrderBy = {
   created_at?: InputMaybe<OrderByDirection>;
   description?: InputMaybe<OrderByDirection>;
-  flavor_id?: InputMaybe<OrderByDirection>;
+  favorite?: InputMaybe<OrderByDirection>;
   id?: InputMaybe<OrderByDirection>;
   name?: InputMaybe<OrderByDirection>;
+  protein_id?: InputMaybe<OrderByDirection>;
   rate?: InputMaybe<OrderByDirection>;
   title?: InputMaybe<OrderByDirection>;
 };
@@ -1322,9 +1343,10 @@ export type ReviewsOrderBy = {
 export type ReviewsUpdateInput = {
   created_at?: InputMaybe<Scalars['Datetime']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
-  flavor_id?: InputMaybe<Scalars['BigInt']['input']>;
+  favorite?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
-  rate?: InputMaybe<Scalars['BigInt']['input']>;
+  protein_id?: InputMaybe<Scalars['BigInt']['input']>;
+  rate?: InputMaybe<Scalars['BigFloat']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1441,7 +1463,7 @@ export type InsertIntoReviewsCollectionMutationVariables = Exact<{
 }>;
 
 
-export type InsertIntoReviewsCollectionMutation = { __typename?: 'Mutation', insertIntoreviewsCollection?: { __typename?: 'reviewsInsertResponse', affectedCount: number, records: Array<{ __typename?: 'reviews', description: string, id: any, name: string, rate: any, title: string, flavor_id: any }> } | null };
+export type InsertIntoReviewsCollectionMutation = { __typename?: 'Mutation', insertIntoreviewsCollection?: { __typename?: 'reviewsInsertResponse', affectedCount: number, records: Array<{ __typename?: 'reviews', description: string, id: any, name: string, rate: any, title: string, protein_id: any }> } | null };
 
 export type MakersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1474,7 +1496,7 @@ export type ReviewsCollectionQueryVariables = Exact<{
 }>;
 
 
-export type ReviewsCollectionQuery = { __typename?: 'Query', reviewsCollection?: { __typename?: 'reviewsConnection', edges: Array<{ __typename?: 'reviewsEdge', node: { __typename?: 'reviews', id: any, name: string, title: string, rate: any, description: string, flavor_id: any } }> } | null };
+export type ReviewsCollectionQuery = { __typename?: 'Query', reviewsCollection?: { __typename?: 'reviewsConnection', edges: Array<{ __typename?: 'reviewsEdge', node: { __typename?: 'reviews', id: any, name: string, title: string, rate: any, description: string, protein_id: any } }> } | null };
 
 
 export const InsertIntoReviewsCollectionDocument = gql`
@@ -1487,7 +1509,7 @@ export const InsertIntoReviewsCollectionDocument = gql`
       name
       rate
       title
-      flavor_id
+      protein_id
     }
   }
 }
@@ -1741,7 +1763,7 @@ export type FactsByProteinIdLazyQueryHookResult = ReturnType<typeof useFactsByPr
 export type FactsByProteinIdQueryResult = Apollo.QueryResult<FactsByProteinIdQuery, FactsByProteinIdQueryVariables>;
 export const ReviewsCollectionDocument = gql`
     query ReviewsCollection($ids: [BigInt!]) {
-  reviewsCollection(filter: {flavor_id: {in: $ids}}) {
+  reviewsCollection(filter: {protein_id: {in: $ids}}) {
     edges {
       node {
         id
@@ -1749,7 +1771,7 @@ export const ReviewsCollectionDocument = gql`
         title
         rate
         description
-        flavor_id
+        protein_id
       }
     }
   }

--- a/api/graphql/mutations.graphql
+++ b/api/graphql/mutations.graphql
@@ -7,7 +7,7 @@ mutation InsertIntoReviewsCollection($objects: [reviewsInsertInput!]!) {
       name
       rate
       title
-      flavor_id
+      protein_id
     }
   }
 }

--- a/api/graphql/queries.graphql
+++ b/api/graphql/queries.graphql
@@ -109,7 +109,7 @@ query FactsByProteinId($id: BigInt!) {
 }
 # フレーバーに紐づくレビューを取得
 query ReviewsCollection($ids: [BigInt!]) {
-  reviewsCollection(filter: { flavor_id: { in: $ids } }) {
+  reviewsCollection(filter: { protein_id: { in: $ids } }) {
     edges {
       node {
         id
@@ -117,7 +117,7 @@ query ReviewsCollection($ids: [BigInt!]) {
         title
         rate
         description
-        flavor_id
+        protein_id
       }
     }
   }

--- a/app/makers/[makerId]/proteins/[proteinId]/_components/proteinContainer.tsx
+++ b/app/makers/[makerId]/proteins/[proteinId]/_components/proteinContainer.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useAtomValue, useAtom } from "jotai"
+import { useAtom } from "jotai"
 import { useEffect } from "react"
-import { flavorAtom, reviewsAtom } from "stores/proteinAtom"
+import { reviewsAtom } from "stores/proteinAtom"
 import { Protein, Review } from "types/responses"
 import ProteinSection from "./proteinSection"
 import ReviewSection from "./reviewSection"
@@ -12,8 +12,6 @@ type Props = {
   reviews?: Review[]
 }
 export default function ProteinContainer({ protein, reviews }: Props) {
-  const flavor = useAtomValue(flavorAtom)
-
   const [displayedReviews, setDisplayedReviews] = useAtom(reviewsAtom)
   useEffect(() => {
     if (reviews) {
@@ -24,7 +22,7 @@ export default function ProteinContainer({ protein, reviews }: Props) {
   return (
     <>
       <ProteinSection protein={protein} />
-      <ReviewSection reviews={displayedReviews} flavor={flavor} />
+      <ReviewSection reviews={displayedReviews} protein={protein} />
     </>
   )
 }

--- a/app/makers/[makerId]/proteins/[proteinId]/_components/reviewSection.tsx
+++ b/app/makers/[makerId]/proteins/[proteinId]/_components/reviewSection.tsx
@@ -1,31 +1,26 @@
 "use client"
 import { notoSansJp } from "@/app/_styles/fonts"
-import { useMemo } from "react"
-import { Flavor, Review } from "types/responses"
+import { Protein, Review } from "types/responses"
 import ReviewForm from "../_templates/reviewForm"
 import ReviewCards from "./reviewCards"
 
 type Props = {
-  flavor: Flavor
+  protein: Protein
   reviews?: Review[]
 }
-export default function ReviewSection({ flavor, reviews }: Props) {
-  const filteredReviews = useMemo(
-    () => reviews?.filter((review) => review.flavor_id === flavor.id),
-    [reviews, flavor],
-  )
+export default function ReviewSection({ protein, reviews }: Props) {
   return (
     <section className="grid gap-8">
       <div>
         <h2
           className={`text-lg lg:text-xl xl:text-2xl font-bold mb-2 md:mb-4 ${notoSansJp.className}`}
         >
-          {flavor.name}のレビュー
+          {protein.name}のレビュー
         </h2>
         <hr className="border-1" />
       </div>
-      <ReviewForm flavorId={flavor.id} />
-      <ReviewCards reviews={filteredReviews} />
+      <ReviewForm protein={protein} />
+      <ReviewCards reviews={reviews} />
     </section>
   )
 }

--- a/app/makers/[makerId]/proteins/[proteinId]/_templates/reviewForm.tsx
+++ b/app/makers/[makerId]/proteins/[proteinId]/_templates/reviewForm.tsx
@@ -11,12 +11,13 @@ import { useForm } from "react-hook-form"
 import { clientReviewRepo } from "repos/client/reviews"
 import { reviewsAtom } from "stores/proteinAtom"
 import styles from "@/app/_styles/animation.module.css"
+import { Protein } from "types/responses"
 
 type Props = {
-  flavorId: number
+  protein: Protein
 }
 
-export default function ReviewForm({ flavorId }: Props) {
+export default function ReviewForm({ protein }: Props) {
   const [reviews, setReviews] = useAtom(reviewsAtom)
   const [insertIntoReviewsCollectionMutation] = useInsertIntoReviewsCollectionMutation()
   const {
@@ -39,14 +40,15 @@ export default function ReviewForm({ flavorId }: Props) {
     clearErrors("rate")
   }
 
-  const onSubmit = async (input: Omit<ReviewsInsertInput, "flavor_id" | "create_at">) => {
+  const onSubmit = async (input: Omit<ReviewsInsertInput, "protein_id" | "create_at">) => {
     try {
       const review = await clientReviewRepo.create(
-        { ...input, flavor_id: flavorId },
+        { ...input, protein_id: protein.id, rate: String(input.rate) },
         insertIntoReviewsCollectionMutation,
       )
       setReviews([review, ...reviews])
       reset()
+      setRate(0)
     } catch (e) {
       console.log(e)
     }


### PR DESCRIPTION
## 概要
- レビューは`flavors`テーブルではなく、`proteins`テーブルに紐づくよう変更したため、それに伴うフロント側の修正を実施
## やったこと
- graphqlのスキーマを更新 cbc37588ee0d49ae88cf57ff2ad2afff16670a12
- レビュー投稿時に渡すパラメータを修正 b8d7dde60b41eff64052c71177e7b437fd185def
## 関連URL
- 
## 確認項目
- [x] レビュー投稿ができる
## 備考
