### PR TITLE
レビューの平均と総数を表示させる

### DIFF
--- a/api/graphql/generated/graphql.ts
+++ b/api/graphql/generated/graphql.ts
@@ -1475,14 +1475,14 @@ export type MakerByIdQueryVariables = Exact<{
 }>;
 
 
-export type MakerByIdQuery = { __typename?: 'Query', makersCollection?: { __typename?: 'makersConnection', edges: Array<{ __typename?: 'makersEdge', node: { __typename?: 'makers', id: any, name: string, src: string, proteinsCollection?: { __typename?: 'proteinsConnection', edges: Array<{ __typename?: 'proteinsEdge', node: { __typename?: 'proteins', id: any, name: string, src: string, maker_id?: any | null } }> } | null } }> } | null };
+export type MakerByIdQuery = { __typename?: 'Query', makersCollection?: { __typename?: 'makersConnection', edges: Array<{ __typename?: 'makersEdge', node: { __typename?: 'makers', id: any, name: string, src: string, proteinsCollection?: { __typename?: 'proteinsConnection', edges: Array<{ __typename?: 'proteinsEdge', node: { __typename?: 'proteins', id: any, name: string, src: string, maker_id?: any | null, reviewsCollection?: { __typename?: 'reviewsConnection', edges: Array<{ __typename?: 'reviewsEdge', node: { __typename?: 'reviews', id: any, rate: any } }> } | null } }> } | null } }> } | null };
 
 export type ProteinByIdQueryVariables = Exact<{
   id: Scalars['BigInt']['input'];
 }>;
 
 
-export type ProteinByIdQuery = { __typename?: 'Query', proteinsCollection?: { __typename?: 'proteinsConnection', edges: Array<{ __typename?: 'proteinsEdge', node: { __typename?: 'proteins', id: any, name: string, src: string, featuresCollection?: { __typename?: 'featuresConnection', edges: Array<{ __typename?: 'featuresEdge', node: { __typename?: 'features', id: any, description: string } }> } | null, flavorsCollection?: { __typename?: 'flavorsConnection', edges: Array<{ __typename?: 'flavorsEdge', node: { __typename?: 'flavors', id: any, name: string, src: string, sellersCollection?: { __typename?: 'sellersConnection', edges: Array<{ __typename?: 'sellersEdge', node: { __typename?: 'sellers', id: any, amazon?: string | null, rakuten?: string | null, yahoo?: string | null, official: string, flavor_id?: any | null } }> } | null, productsCollection?: { __typename?: 'productsConnection', edges: Array<{ __typename?: 'productsEdge', node: { __typename?: 'products', id: any, capacity: string, price: string, flavor_id?: any | null } }> } | null } }> } | null } }> } | null };
+export type ProteinByIdQuery = { __typename?: 'Query', proteinsCollection?: { __typename?: 'proteinsConnection', edges: Array<{ __typename?: 'proteinsEdge', node: { __typename?: 'proteins', id: any, name: string, src: string, featuresCollection?: { __typename?: 'featuresConnection', edges: Array<{ __typename?: 'featuresEdge', node: { __typename?: 'features', id: any, description: string } }> } | null, flavorsCollection?: { __typename?: 'flavorsConnection', edges: Array<{ __typename?: 'flavorsEdge', node: { __typename?: 'flavors', id: any, name: string, src: string, sellersCollection?: { __typename?: 'sellersConnection', edges: Array<{ __typename?: 'sellersEdge', node: { __typename?: 'sellers', id: any, amazon?: string | null, rakuten?: string | null, yahoo?: string | null, official: string, flavor_id?: any | null } }> } | null, productsCollection?: { __typename?: 'productsConnection', edges: Array<{ __typename?: 'productsEdge', node: { __typename?: 'products', id: any, capacity: string, price: string, flavor_id?: any | null } }> } | null } }> } | null, reviewsCollection?: { __typename?: 'reviewsConnection', edges: Array<{ __typename?: 'reviewsEdge', node: { __typename?: 'reviews', id: any, name: string, title: string, favorite?: string | null, rate: any, description: string, protein_id: any } }> } | null } }> } | null };
 
 export type FactsByProteinIdQueryVariables = Exact<{
   id: Scalars['BigInt']['input'];
@@ -1595,6 +1595,14 @@ export const MakerByIdDocument = gql`
               name
               src
               maker_id
+              reviewsCollection {
+                edges {
+                  node {
+                    id
+                    rate
+                  }
+                }
+              }
             }
           }
         }
@@ -1675,6 +1683,19 @@ export const ProteinByIdDocument = gql`
                   }
                 }
               }
+            }
+          }
+        }
+        reviewsCollection {
+          edges {
+            node {
+              id
+              name
+              title
+              favorite
+              rate
+              description
+              protein_id
             }
           }
         }

--- a/api/graphql/queries.graphql
+++ b/api/graphql/queries.graphql
@@ -26,6 +26,14 @@ query MakerById($id: BigInt!) {
               name
               src
               maker_id
+              reviewsCollection {
+                edges {
+                  node {
+                    id
+                    rate
+                  }
+                }
+              }
             }
           }
         }
@@ -78,6 +86,19 @@ query ProteinById($id: BigInt!) {
                   }
                 }
               }
+            }
+          }
+        }
+        reviewsCollection {
+          edges {
+            node {
+              id
+              name
+              title
+              favorite
+              rate
+              description
+              protein_id
             }
           }
         }

--- a/app/_components/lists/list.tsx
+++ b/app/_components/lists/list.tsx
@@ -3,10 +3,6 @@ type Props = {
   children: React.ReactNode
 }
 
-export default function List({ key, children }: Props) {
-  return (
-    <li key={key} className="grid gap-1 md:gap-2">
-      {children}
-    </li>
-  )
+export default function List({ children }: Props) {
+  return <li className="grid gap-1 md:gap-2">{children}</li>
 }

--- a/app/makers/[makerId]/_components/proteinList.tsx
+++ b/app/makers/[makerId]/_components/proteinList.tsx
@@ -4,18 +4,21 @@ import UnorderedList from "@/app/_components/lists/unorderedList"
 import Rate from "@/app/_components/rate"
 import { montSerrat } from "@/app/_styles/fonts"
 import { staticUrl } from "_constants/urls"
-import { Proteins } from "api/graphql/generated/graphql"
-import { createStaticUrl } from "modules/utils"
+import { calculateRateAverage, createStaticUrl } from "modules/utils"
 import Link from "next/link"
+import { ProteinByMakerIdResponse } from "types/responses"
 
 type Props = {
-  proteins: Pick<Proteins, "__typename" | "id" | "name" | "src" | "maker_id">[]
+  proteins: Pick<
+    ProteinByMakerIdResponse,
+    "__typename" | "id" | "name" | "src" | "maker_id" | "reviews"
+  >[]
 }
 
 export default function ProteinList({ proteins }: Props) {
   return (
     <UnorderedList>
-      {proteins.map(({ id, src, name, maker_id }) => (
+      {proteins.map(({ id, src, name, maker_id, reviews }) => (
         <List key={id}>
           <Link href={`/makers/${maker_id}/proteins/${id}`}>
             <div className="grid gap-2 group">
@@ -35,8 +38,7 @@ export default function ProteinList({ proteins }: Props) {
                 <p className={`text-xs lg:text-sm font-bold text-gray-400 ${montSerrat.className}`}>
                   {name}
                 </p>
-                {/* TODO: 数値入れ替え */}
-                <Rate rate={2} count={50} />
+                <Rate rate={calculateRateAverage(reviews)} count={reviews.length} />
               </div>
             </div>
           </Link>

--- a/app/makers/[makerId]/proteins/[proteinId]/_components/proteinSection.tsx
+++ b/app/makers/[makerId]/proteins/[proteinId]/_components/proteinSection.tsx
@@ -6,7 +6,7 @@ import PageTitle from "@/app/_components/pageTitle"
 import Rate from "@/app/_components/rate"
 import { notoSansJp, montSerrat } from "@/app/_styles/fonts"
 import { staticUrl } from "_constants/urls"
-import { createStaticUrl, convertKey } from "modules/utils"
+import { createStaticUrl, convertKey, calculateRateAverage } from "modules/utils"
 import { useMemo, useCallback, useEffect, Fragment } from "react"
 import { flavorAtom, productAtom } from "stores/proteinAtom"
 import { Protein, ShopKey, Product } from "types/responses"
@@ -30,6 +30,7 @@ export default function ProteinSection({ protein }: Props) {
   ) as ShopKey[]
 
   const price = useMemo(() => product.price, [product.price])
+  const average = calculateRateAverage(protein.reviews)
 
   const onChange = useCallback(
     (id: string) => {
@@ -69,7 +70,7 @@ export default function ProteinSection({ protein }: Props) {
       <div className="grid gap-2">
         <div>
           <PageTitle> {protein.name}</PageTitle>
-          <Rate rate={3} count={50}></Rate>
+          <Rate rate={average} count={protein.reviews.length}></Rate>
         </div>
         <FeatureList features={protein.features} />
         <hr className="border-1" />

--- a/modules/utils.ts
+++ b/modules/utils.ts
@@ -1,4 +1,4 @@
-import { ShopKey } from "../types/responses"
+import { Review, ShopKey } from "../types/responses"
 
 /**
  * @description 画像のURLを生成する
@@ -27,4 +27,15 @@ export const convertKey = (key: ShopKey) => {
     case "official":
       return "公式サイト"
   }
+}
+
+/**
+ * @description rateの平均を計算する
+ * @param reviews レビュー一覧
+ * @return rateの平均
+ */
+export const calculateRateAverage = (reviews: Review[] | Pick<Review, "id" | "rate">[]) => {
+  const rateSum = reviews.reduce((sum, review) => sum + Number(review.rate), 0)
+
+  return Math.round(rateSum / reviews.length)
 }

--- a/repos/makers.ts
+++ b/repos/makers.ts
@@ -36,8 +36,14 @@ export const makerRepo = {
     if (error) throw error
 
     const node = makersCollection?.edges?.[0]?.node
-    if (!node) throw new Error("Maker not found")
-    const proteins = node?.proteinsCollection?.edges?.map((edge) => edge?.node)
+    const proteins = node?.proteinsCollection?.edges?.map((edge) => {
+      return {
+        ...edge?.node,
+        reviews: edge?.node?.reviewsCollection?.edges?.map((edge) => edge?.node) ?? [],
+      }
+    })
+    if (!node || !proteins) throw new Error("Data not found")
+
     return { maker: node, proteins }
   },
 }

--- a/repos/proteins.ts
+++ b/repos/proteins.ts
@@ -25,7 +25,7 @@ export const proteinRepo = {
     if (!protein) throw new Error("Protein not found")
 
     const features = protein?.featuresCollection?.edges?.map((edge) => edge?.node)
-
+    const reviews = protein?.reviewsCollection?.edges?.map((edge) => edge?.node)
     const flavors = protein?.flavorsCollection?.edges?.map((edge) => edge?.node)
     const sellers = flavors
       ?.map((flavor) => flavor?.sellersCollection?.edges?.map((edge) => edge?.node))
@@ -54,6 +54,7 @@ export const proteinRepo = {
         src: protein.src,
         flavors: combinedFlavors,
         features,
+        reviews: reviews ?? [],
       },
     }
   },

--- a/types/responses.d.ts
+++ b/types/responses.d.ts
@@ -1,11 +1,14 @@
+import { makerRepo } from "repos/makers"
 import { clientFactRepo } from "../repos/client/facts"
 import { proteinRepo } from "../repos/proteins"
 import { reviewRepo } from "../repos/reviews"
 import { UnWrapArray } from "./utils"
 
+export type MakerIdResponse = Awaited<ReturnType<typeof makerRepo.fetchById>>
 export type ProteinIdResponse = Awaited<ReturnType<typeof proteinRepo.fetchById>>
 export type ReviewByFlavorIdResponse = Awaited<ReturnType<typeof reviewRepo.fetchByFlavorIds>>
 export type FactByProteinIdResponse = ReturnType<typeof clientFactRepo.fetchByProteinId>
+export type ProteinByMakerIdResponse = UnWrapArray<MakerIdResponse["proteins"]>
 export type Protein = ProteinIdResponse["protein"]
 export type Fact = FactByProteinIdResponse["fact"]
 export type Nutrient = UnWrapArray<Fact["nutrients"]>


### PR DESCRIPTION
## やったこと
- メーカーに紐づくプロテイン取得時にレビュー一覧も取得できるようリクエストフィールドを修正 [6129b17](https://github.com/ToruShimizu/protein-the-star/pull/160/commits/6129b17b82ec893f0e2bbb486c89dffc45d3f1f3)
- レビュー評価の平均を計算する関数を追加 [2f11c70](https://github.com/ToruShimizu/protein-the-star/pull/160/commits/2f11c70a4ce89f6f1df7958595b976ca4cdd57e3)
- 取得したレビューをもとに平均値と総数を表示するよう変更 [12a2c0b](https://github.com/ToruShimizu/protein-the-star/pull/160/commits/12a2c0bd48c1b4d70ccfcc87adf5701a12a3f6e3)
- 不要なpropsが見つかったため削除 [199609b](https://github.com/ToruShimizu/protein-the-star/pull/160/commits/199609ba5286fae2636275d8827f5f80151b9e56)
## 関連URL

## 確認項目

## 備考
