### PR TITLE
next/fontをビルトインのものに変更

### DIFF
--- a/app/_styles/fonts.ts
+++ b/app/_styles/fonts.ts
@@ -1,4 +1,4 @@
-import { Montserrat, Noto_Sans_JP, Varela_Round, Reggae_One } from "@next/font/google"
+import { Montserrat, Noto_Sans_JP, Varela_Round, Reggae_One } from "next/font/google"
 
 /**
  * サイト名

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@apollo/client": "^3.8.1",
     "@apollo/experimental-nextjs-app-support": "^0.4.2",
     "@hookform/resolvers": "^3.3.1",
-    "@next/font": "^13.4.19",
     "@supabase/supabase-js": "^2.31.0",
     "graphql": "^16.8.0",
     "jotai": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,11 +1116,6 @@
   dependencies:
     glob "7.1.7"
 
-"@next/font@^13.4.19":
-  version "13.4.19"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.19.tgz#2b69aee760a3bbabf54873f80ae6d4b09b35d133"
-  integrity sha512-yOuSRYfqksWcaG/sATr1/DEGvvI8gnmAAnQCCZ0+L9p4Pio3/DMu71J56YHh9Hz84LDN4tMVzuux0ssCuM50sA==
-
 "@next/swc-darwin-arm64@13.4.19":
   version "13.4.19"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz#77ad462b5ced4efdc26cb5a0053968d2c7dac1b6"


### PR DESCRIPTION
## やったこと
- next v13.2以降はビルトインのフォントが使用できるみたいなので入れ替えを実施
    - https://nextjs.org/docs/messages/built-in-next-font 
## 関連URL

## 確認項目

## 備考
