### PR TITLE
fix: rateをnumber型に変換する

### DIFF
--- a/app/makers/[makerId]/_components/proteinList.tsx
+++ b/app/makers/[makerId]/_components/proteinList.tsx
@@ -17,8 +17,6 @@ type Props = {
 }
 
 export default function ProteinList({ proteins }: Props) {
-  console.log(proteins[0].src)
-
   return (
     <UnorderedList>
       {proteins.map(({ id, src, name, maker_id, reviews }) => (

--- a/app/makers/[makerId]/proteins/[proteinId]/_components/reviewCards.tsx
+++ b/app/makers/[makerId]/proteins/[proteinId]/_components/reviewCards.tsx
@@ -14,7 +14,7 @@ export default function ReviewCards({ reviews }: Props) {
           <div key={review.id} className="grid gap-1 p-4 border border-gray-200 rounded-lg shadow">
             <h5 className="text-base font-bold">{review.title}</h5>
             <p className="text-sm text-neutral-600">{review.name}</p>
-            <Rate rate={review.rate} />
+            <Rate rate={Number(review.rate)} />
             <p className="text-sm text-neutral-600">{review.description}</p>
           </div>
         ))}


### PR DESCRIPTION
## やったこと
- rateがstring型として返却されてくるため、numberに変換して渡すよう修正 [346bbf3](https://github.com/ToruShimizu/protein-the-star/pull/166/commits/346bbf3d64346e18bb0fd617befab2ccfae9bc2d)
    - 後日、numberとして返却されるよう修正する
- console.logが残っていたため削除 [d106a0d](https://github.com/ToruShimizu/protein-the-star/pull/166/commits/d106a0d0f6dfc63e467457bf39b05a47f580af1b)
## 関連URL

## 確認項目

## 備考
